### PR TITLE
Updated Sodium

### DIFF
--- a/versions.yml
+++ b/versions.yml
@@ -38,7 +38,7 @@ modGroups:
       homepage: https://modrinth.com/mod/sodium
       modrinthId: AANobbMI
       desc: Greatly improves rendering performance
-      url: https://cdn.modrinth.com/data/AANobbMI/versions/Nr39FOaS/sodium-fabric-mc1.19.3-0.4.6%2Bbuild.20.jar
+      url: https://cdn.modrinth.com/data/AANobbMI/versions/idtcaIVT/sodium-fabric-mc1.19.3-0.4.9%2Bbuild.23.jar
 
     - name: Mod menu
       license: MIT


### PR DESCRIPTION
Forgot to update sodium in my recent pull request. With the old version you can't start the game at all because some other mods depend on this.