### PR TITLE
fix: Require Cloth Config for VoW

### DIFF
--- a/versions.yml
+++ b/versions.yml
@@ -168,6 +168,7 @@ modGroups:
       homepage: https://voicesofwynn.com
       desc: Adds voice lines to Wynncraft
       url: https://voicesofwynn.com/download/42/jar
+      requires: [Cloth Config]
 
   Visual Enhancements:
     - name: Distant Horizons


### PR DESCRIPTION
This "fixes" VoW's issue where they have a soft dependency on cloth config, but fail to launch without it.