### PR TITLE
Update Voices of Wynn to version 1.5.1

### DIFF
--- a/versions.yml
+++ b/versions.yml
@@ -169,7 +169,7 @@ modGroups:
       license: GPL-3.0
       homepage: https://voicesofwynn.com
       desc: Adds voice lines to Wynncraft
-      url: https://voicesofwynn.com/download/44/jar
+      url: https://voicesofwynn.com/download/46/jar
       requires: [Cloth Config]
 
   Visual Enhancements:


### PR DESCRIPTION
This patch version fixes a critical bug caused by changes in Wynncraft's chat system. Ask @kmaxii if you need more info.