### PR TITLE
Updated and added old mods

### DIFF
--- a/versions.yml
+++ b/versions.yml
@@ -1,4 +1,4 @@
-fabricVersion: 0.14.22
+fabricVersion: 0.15.0
 minecraftVersion: 1.20.2
 groups:
   - name: Core
@@ -31,7 +31,7 @@ modGroups:
       homepage: https://modrinth.com/mod/fabric-api
       modrinthId: P7dR8mSH
       desc: The core api used by fabric mods
-      url: https://cdn.modrinth.com/data/P7dR8mSH/versions/Hk8zAzIB/fabric-api-0.90.0%2B1.20.2.jar
+      url: https://cdn.modrinth.com/data/P7dR8mSH/versions/qg6wQgub/fabric-api-0.91.1%2B1.20.2.jar
 
     - name: Sodium
       license: LGPL-3
@@ -95,7 +95,7 @@ modGroups:
       homepage: https://modrinth.com/mod/forcecloseworldloadingscreen
       modrinthId: blWBX5n1
       desc: Improves loading times when changing worlds
-      url: https://cdn.modrinth.com/data/blWBX5n1/versions/thTIgDLT/forcecloseloadingscreen-2.1.1.jar
+      url: https://cdn.modrinth.com/data/blWBX5n1/versions/hIUIDW3m/forcecloseloadingscreen-2.2.0.jar
 
     - name: Cull Particles
       license: CC0
@@ -123,14 +123,21 @@ modGroups:
       homepage: https://modrinth.com/mod/ferrite-core
       modrinthId: uXXizFIs
       desc: Optimizes memory usage
-      url: https://cdn.modrinth.com/data/uXXizFIs/versions/FCnCG6PS/ferritecore-6.0.0-fabric.jar
+      url: https://cdn.modrinth.com/data/uXXizFIs/versions/unerR5MN/ferritecore-6.0.1-fabric.jar
 
     - name: ModernFix
       license: LGPL-3
       homepage: https://modrinth.com/mod/modernfix
       modrinthId: nmDcB62a
       desc: All-in-one optimization mod
-      url: https://cdn.modrinth.com/data/nmDcB62a/versions/ADyFF3WV/modernfix-fabric-5.7.5%2Bmc1.20.2.jar
+      url: https://cdn.modrinth.com/data/nmDcB62a/versions/IC7LBv4d/modernfix-fabric-5.10.0%2Bmc1.20.2.jar
+
+    - name: Enhanced Block Entities
+      license: LGPL-3
+      homepage: https://modrinth.com/mod/ebe
+      desc: Makes blocks like chests render faster and nicer
+      url: https://cdn.modrinth.com/data/OVuFYfre/versions/eIFo7wvq/enhancedblockentities-0.9.1%2B1.20.2.jar
+      configUrl: https://github.com/MineInAbyss/launchy-mods/releases/download/v1.0.0/enhanced_bes_1.1.zip
 
   Wynncraft Enhancements:
     - name: WynnLib
@@ -172,6 +179,14 @@ modGroups:
       incompatibleWith: [Distant Horizons]
       requires: [Cloth Config]
 
+    - name: Distant Horizons
+      license: LGPL-3
+      homepage: https://modrinth.com/mod/distanthorizons
+      modrinthId: uCdwusMi
+      desc: Level-Of-Detail mod to allow for better performance and higher render-distance
+      url: https://cdn.modrinth.com/data/uCdwusMi/versions/3yoHVgxZ/DistantHorizons-2.0.1-a-1.20.2.jar
+      incompatibleWith: [Iris shaders, Bobby]
+
     - name: Falling leaves
       license: MIT
       homepage: https://modrinth.com/mod/fallingleaves
@@ -186,7 +201,7 @@ modGroups:
       homepage: https://modrinth.com/mod/lambdynamiclights
       modrinthId: yBW8D80W
       desc: Holding a torch will light up your surroundings
-      url: https://cdn.modrinth.com/data/yBW8D80W/versions/mYl4RvKg/lambdynamiclights-2.3.2%2B1.20.1.jar
+      url: https://cdn.modrinth.com/data/yBW8D80W/versions/i6nks8QI/lambdynamiclights-2.3.3%2B1.20.2.jar
 
     - name: Visuality
       license: MIT
@@ -222,14 +237,14 @@ modGroups:
       homepage: https://modrinth.com/mod/entity-model-features
       modrinthId: 4I1XuqiY
       desc: Adds Model Features to entities in Optifine compatible format.
-      url: https://cdn.modrinth.com/data/4I1XuqiY/versions/eg7GqpgR/entity_model_features_fabric_1.20.2-1.0.2.jar
+      url: https://cdn.modrinth.com/data/BVzZfTc1/versions/2zQ0rZri/entity_texture_features_fabric_1.20.2-4.6.1.jar
 
     - name: Entity Model Features
       license: LGPL 3.0 only
       homepage: https://modrinth.com/mod/entitytexturefeatures
       modrinthId: BVzZfTc1
       desc: Adds Texture Features to entities in Optifine compatible format.
-      url: https://cdn.modrinth.com/data/BVzZfTc1/versions/1Y3lxOX6/entity_texture_features_fabric_1.20.2-4.5.1.jar
+      url: https://cdn.modrinth.com/data/4I1XuqiY/versions/OsioKrT1/entity_model_features_fabric_1.20.2-1.1.0.jar
 
     - name: Continuity
       license: LGPL-3
@@ -286,6 +301,13 @@ modGroups:
       url: https://cdn.modrinth.com/data/T8MMXTpr/versions/7GB1hLrr/DripSounds-1.19.4-0.3.2.jar
       requires: [Cloth Config]
 
+    - name: Presence Footsteps
+      license: MIT
+      homepage: https://modrinth.com/mod/presence-footsteps
+      modrinthId: rcTfTZr3
+      desc: Improved stepping sound effects
+      url: https://cdn.modrinth.com/data/rcTfTZr3/versions/KrTss88l/PresenceFootsteps-1.10.0.jar
+
   HUD & Menu Enhancements:
     - name: Reese's Sodium Options
       license: MIT
@@ -307,8 +329,17 @@ modGroups:
       homepage: https://modrinth.com/mod/betterf3
       modrinthId: 8shC1gFX
       desc: Makes the F3-menu customizable and cleaner
-      url: https://cdn.modrinth.com/data/8shC1gFX/versions/o935ywNh/BetterF3-8.0.1-Fabric-1.20.2.jar
+      url: https://cdn.modrinth.com/data/8shC1gFX/versions/sPcACJ3r/BetterF3-8.0.2-Fabric-1.20.2.jar
       configUrl: https://github.com/MineInAbyss/launchy-mods/releases/download/v1.0.0/BetterF3_1.0.zip
+
+    - name: Desired Servers
+      license: MIT
+      homepage: https://modrinth.com/mod/desired-servers
+      modrinthId: GDpe4LHD
+      desc: Ship servers without modifying servers.dat
+      url: https://cdn.modrinth.com/data/GDpe4LHD/versions/6WCSTVyB/desiredservers-fabric-1.20.2-1.3.0.jar
+      configUrl: https://github.com/Wynntils/launchy-config/releases/download/v0.0.1-rc.0/DesiredServers.zip
+      forceConfigDownload: true
 
   Misc Enhancements:
     - name: First Person Models
@@ -316,7 +347,7 @@ modGroups:
       homepage: https://modrinth.com/mod/first-person-model
       modrinthId: H5XMjpHi
       desc: Enables the third-person model in first-person, making for a more realistic experience
-      url: https://cdn.modrinth.com/data/H5XMjpHi/versions/szmxJfsR/firstperson-fabric-2.2.3-mc1.20.2.jar
+      url: https://cdn.modrinth.com/data/H5XMjpHi/versions/sAIjL2oE/firstperson-fabric-2.2.4-mc1.20.2.jar
 
     - name: Boat Item View
       license: LGPL-3
@@ -338,7 +369,7 @@ modGroups:
       homepage: https://modrinth.com/mod/borderless-mining
       modrinthId: kYq5qkSL
       desc: Changes the fullscreen option to use a borderless window that fills the screen.
-      url: https://cdn.modrinth.com/data/kYq5qkSL/versions/lhrW53q7/borderless-mining-1.1.8%2B1.20.1.jar
+      url: https://cdn.modrinth.com/data/kYq5qkSL/versions/r2hHx4zB/borderless-mining-1.1.9%2B1.20.2.jar
 
     - name: Zoomify
       license: LGPL-3
@@ -388,7 +419,7 @@ modGroups:
       license: MIT
       homepage: https://modrinth.com/mod/rei
       desc: Alternative to Just Enough Items
-      url: https://cdn.modrinth.com/data/nfn13YXA/versions/PK9IHKYO/RoughlyEnoughItems-13.0.666.jar
+      url: https://cdn.modrinth.com/data/nfn13YXA/versions/CIz40xpM/RoughlyEnoughItems-13.0.678.jar
       requires: [ArchitecturyAPI]
 
     - name: NBTToolTips
@@ -405,13 +436,20 @@ modGroups:
       desc: Performance Profiler
       url: https://cdn.modrinth.com/data/l6YH9Als/versions/tCU9VuzX/spark-1.10.54-fabric.jar
 
+    - name: IBE Editor
+      license: MIT
+      homepage: https://modrinth.com/mod/ibe-editor
+      modrinthId: E9sX1ncV
+      desc: Simple GUI Mod to edit an item, a block or an entity in your current world
+      url: https://cdn.modrinth.com/data/E9sX1ncV/versions/YBAw7WnA/IBEEditor-1.20.2-2.2.6-fabric.jar
+
   Dependencies:
     - name: ArchitecturyAPI
       license: LGPL-3
       homepage: https://modrinth.com/mod/architectury-api
       modrinthId: lhGA9TYQ
       desc: Dependency for RoughlyEnoughItems
-      url: https://cdn.modrinth.com/data/lhGA9TYQ/versions/cv151FBM/architectury-10.0.8-fabric.jar
+      url: https://cdn.modrinth.com/data/lhGA9TYQ/versions/TcnLTl81/architectury-10.0.16-fabric.jar
       dependency: true
 
     - name: FabricKotlinLanguage
@@ -419,7 +457,7 @@ modGroups:
       homepage: https://modrinth.com/mod/fabric-language-kotlin
       modrinthId: Ha28R6CL
       desc: Language Dependency for some mods
-      url: https://cdn.modrinth.com/data/Ha28R6CL/versions/48ri5y9r/fabric-language-kotlin-1.10.10%2Bkotlin.1.9.10.jar
+      url: https://cdn.modrinth.com/data/Ha28R6CL/versions/VJUqKopR/fabric-language-kotlin-1.10.16%2Bkotlin.1.9.21.jar
       dependency: true
 
     - name: Cloth Config
@@ -427,7 +465,7 @@ modGroups:
       homepage: https://modrinth.com/mod/cloth-config
       modrinthId: 9s6osm5g
       desc: A config API used by many mods
-      url: https://cdn.modrinth.com/data/9s6osm5g/versions/LnfolBYb/cloth-config-12.0.109-fabric.jar
+      url: https://cdn.modrinth.com/data/9s6osm5g/versions/jvy82BGQ/cloth-config-12.0.111-fabric.jar
       dependency: true
 
     - name: Forge Config API Port
@@ -435,7 +473,7 @@ modGroups:
       homepage: https://modrinth.com/mod/forge-config-api-port
       modrinthId: ohNO6lps
       desc: Forge Config API ported to Fabric
-      url: https://cdn.modrinth.com/data/ohNO6lps/versions/f5d9VI72/ForgeConfigAPIPort-v9.0.0-1.20.2-Fabric.jar
+      url: https://cdn.modrinth.com/data/ohNO6lps/versions/lQ2BNzNV/ForgeConfigAPIPort-v9.1.2-1.20.2-Fabric.jar
       dependency: true
 
     - name: Yet Another Config Lib
@@ -443,7 +481,7 @@ modGroups:
       homepage: https://modrinth.com/mod/yacl
       modrinthId: 1eAoo2KR
       desc: Yet Another Config Lib, like, what were you expecting?
-      url: https://cdn.modrinth.com/data/1eAoo2KR/versions/u6jV7Q7R/yet-another-config-lib-fabric-3.2.1%2B1.20.2.jar
+      url: https://cdn.modrinth.com/data/1eAoo2KR/versions/vede4iWJ/yet-another-config-lib-fabric-3.3.0-beta.1%2B1.20.2.jar
       dependency: true
 
     - name: Searchables
@@ -451,7 +489,7 @@ modGroups:
       homepage: https://modrinth.com/mod/searchables
       modrinthId: fuuu3xnx
       desc: Library mod that adds methods for easier searching
-      url: https://cdn.modrinth.com/data/fuuu3xnx/versions/vQ8Sa7rD/Searchables-fabric-1.20.2-1.0.2.jar
+      url: https://cdn.modrinth.com/data/fuuu3xnx/versions/L6tli89N/Searchables-fabric-1.20.2-1.0.3.jar
       dependency: true
 
   Outdated/Disabled:
@@ -468,15 +506,6 @@ modGroups:
       modrinthId: vRXn3MrA
       desc: Removes light-update when unloading chunks to fix lag spikes
       url: https://cdn.modrinth.com/data/vRXn3MrA/versions/1.0.4/forgetmechunk-1.0.4-1.18.X-1.19.X.jar
-
-    - name: Desired Servers
-      license: MIT
-      homepage: https://modrinth.com/mod/desired-servers
-      modrinthId: GDpe4LHD
-      desc: Ship servers without modifying servers.dat
-      url: https://cdn.modrinth.com/data/GDpe4LHD/versions/4F5sOpkI/desiredservers-fabric-1.19.2-1.1.0.jar
-      configUrl: https://github.com/Wynntils/launchy-config/releases/download/v0.0.1-rc.0/DesiredServers.zip
-      forceConfigDownload: true
 
     - name: ExtraSounds
       license: CC0
@@ -504,64 +533,11 @@ modGroups:
       desc: Adds a few performance improvements to increase fps
       url: https://mediafilez.forgecdn.net/files/4522/380/betterfpsdist-fabric-1.19.4-2.5.jar
 
-    - name: Enhanced Block Entities
-      license: LGPL-3
-      homepage: https://modrinth.com/mod/ebe
-      desc: Makes blocks like chests render faster and nicer
-      url: https://cdn.modrinth.com/data/OVuFYfre/versions/Xdo5ZiRc/enhancedblockentities-0.9%2B1.19.4.jar
-      configUrl: https://github.com/MineInAbyss/launchy-mods/releases/download/v1.0.0/enhanced_bes_1.1.zip
-
-    - name: ForgetMeChunk
-      license: No License
-      homepage: https://modrinth.com/mod/forgetmechunk
-      modrinthId: vRXn3MrA
-      desc: Removes light-update when unloading chunks to fix lag spikes
-      url: https://cdn.modrinth.com/data/vRXn3MrA/versions/1.0.4/forgetmechunk-1.0.4-1.18.X-1.19.X.jar
-
-    - name: ExtraSounds
-      license: CC0
-      homepage: https://modrinth.com/mod/extrasounds
-      desc: Adds more sounds to Minecraft
-      url: https://artifactory.kow08absty.com/artifactory/fabricmc/dev/stashy/extra-sounds/2.3.1%2B1.19.3~lonefelidae16-SNAPSHOT/extra-sounds-2.3.1%2B1.19.3~lonefelidae16-20230111.075334-2.jar
-
-    - name: ClearSkies
-      license: LGPL-3
-      homepage: https://modrinth.com/mod/clear-skies
-      modrinthId: xNK6XfRv
-      desc: Removes the banding at the horizon of Vanilla Minecraft
-      url: https://cdn.modrinth.com/data/xNK6XfRv/versions/SSFjIc6G/clear-skies-fabric-mc119-2.0.96.jar
-
-    - name: Desired Servers
-      license: MIT
-      homepage: https://modrinth.com/mod/desired-servers
-      modrinthId: GDpe4LHD
-      desc: Ship servers without modifying servers.dat
-      url: https://cdn.modrinth.com/data/GDpe4LHD/versions/4F5sOpkI/desiredservers-fabric-1.19.2-1.1.0.jar
-      configUrl: https://github.com/Wynntils/launchy-config/releases/download/v0.0.1-rc.0/DesiredServers.zip
-      forceConfigDownload: true
-
-    - name: Distant Horizons
-      license: LGPL-3
-      homepage: https://modrinth.com/mod/distanthorizons
-      modrinthId: uCdwusMi
-      desc: Level-Of-Detail mod to allow for better performance and higher render-distance
-      url: https://cdn.modrinth.com/data/uCdwusMi/versions/xBHpiuwg/DistantHorizons-1.6.11a-1.19.4.jar
-      configUrl: https://github.com/Wynntils/launchy-config/releases/download/v0.0.1-rc.0/DistantHorizons.zip
-      configDesc: "Includes cached chunks for Wynncraft"
-      incompatibleWith: [Iris shaders, Bobby]
-
     - name: Dynamic Sound filters
       license: APACHE
       homepage: https://www.curseforge.com/minecraft/mc-mods/dynamic-sound-filters
       desc: Adds sound filters depending on your current location
       url: https://mediafilez.forgecdn.net/files/4438/899/DynamicSoundFilters-1.4.0%2B1.19.4.jar
-
-    - name: Presence Footsteps
-      license: MIT
-      homepage: https://modrinth.com/mod/presence-footsteps
-      modrinthId: rcTfTZr3
-      desc: Improved stepping sound effects
-      url: https://cdn.modrinth.com/data/rcTfTZr3/versions/jxsFtML2/PresenceFootsteps-1.8.2.jar
 
     - name: Dont Clear Chat History
       license: CC0
@@ -577,13 +553,6 @@ modGroups:
       desc: Adds a configurable zoom key.
       url: https://cdn.modrinth.com/data/8bOImuGU/versions/i2lqyeCD/logical_zoom-0.0.19.jar
       incompatibleWith: [Zoomify]
-
-    - name: IBE Editor
-      license: MIT
-      homepage: https://modrinth.com/mod/ibe-editor
-      modrinthId: E9sX1ncV
-      desc: Simple GUI Mod to edit an item, a block or an entity in your current world
-      url: https://cdn.modrinth.com/data/E9sX1ncV/versions/aAcdR2Mn/IBEEditor-1.19.4-2.2.2-fabric.jar
 
     - name: Blur
       license: MIT


### PR DESCRIPTION
I also removed duplicated entries in Outdated/Disabled category and removed the cache for Distant Horizons as it is no longer working after 2.0 update, we would have to regenerate it.
Sodium and Iris is not updated as Indium is not updated, and it required by a few of the mods.