### PR TITLE
Enable back Roughly Enough Items

### DIFF
--- a/versions.yml
+++ b/versions.yml
@@ -554,7 +554,7 @@ modGroups:
       desc: Allows you to change which account you are logged in to in-game.
       url: https://cdn.modrinth.com/data/cudtvDnd/versions/3n8w27Oj/InGameAccountSwitcher-Fabric-1.20.2-8.0.2.jar
 
-    - name: Roughly Enough Items - REI
+    - name: RoughlyEnoughItems
       license: MIT
       homepage: https://modrinth.com/mod/rei
       desc: Alternative to Just Enough Items

--- a/versions.yml
+++ b/versions.yml
@@ -429,7 +429,6 @@ modGroups:
       requires: [ArchitecturyAPI]
       incompatibleWith: [ModernFix]
 
-
   Dependencies:
     - name: ArchitecturyAPI
       license: LGPL-3

--- a/versions.yml
+++ b/versions.yml
@@ -421,6 +421,15 @@ modGroups:
       desc: Simple GUI Mod to edit an item, a block or an entity in your current world
       url: https://cdn.modrinth.com/data/E9sX1ncV/versions/bTITl68h/IBEEditor-1.20.2-2.2.8-fabric.jar
 
+    - name: RoughlyEnoughItems
+      license: MIT
+      homepage: https://modrinth.com/mod/rei
+      desc: Alternative to Just Enough Items
+      url: https://cdn.modrinth.com/data/nfn13YXA/versions/GEqwuKdB/RoughlyEnoughItems-13.1.726-fabric.jar
+      requires: [ArchitecturyAPI]
+      incompatibleWith: [ModernFix]
+
+
   Dependencies:
     - name: ArchitecturyAPI
       license: LGPL-3
@@ -553,10 +562,3 @@ modGroups:
       modrinthId: cudtvDnd
       desc: Allows you to change which account you are logged in to in-game.
       url: https://cdn.modrinth.com/data/cudtvDnd/versions/3n8w27Oj/InGameAccountSwitcher-Fabric-1.20.2-8.0.2.jar
-
-    - name: RoughlyEnoughItems
-      license: MIT
-      homepage: https://modrinth.com/mod/rei
-      desc: Alternative to Just Enough Items
-      url: https://cdn.modrinth.com/data/nfn13YXA/versions/GEqwuKdB/RoughlyEnoughItems-13.1.726-fabric.jar
-      requires: [ArchitecturyAPI]


### PR DESCRIPTION
Due to my blunder with the update where I for some reason fought updating the name was a good idea so I changed Rei's name and also disabled it due to issues with something I couldn't find. After some research I found the cause so I brought it back with the revert to the name so it won't cause issues anymore