### PR TITLE
feat: Introduce displayName and fix text overlap

### DIFF
--- a/src/main/kotlin/com/wynntils/launchy/data/Mod.kt
+++ b/src/main/kotlin/com/wynntils/launchy/data/Mod.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class Mod(
     val name: String,
+    val displayName: String = "",
     val license: String = "Unknown",
     val homepage: String = "",
     val desc: String,

--- a/src/main/kotlin/com/wynntils/launchy/ui/screens/settings/ModInfo.kt
+++ b/src/main/kotlin/com/wynntils/launchy/ui/screens/settings/ModInfo.kt
@@ -69,7 +69,8 @@ fun ModInfo(group: Group, mod: Mod) {
                 )
 
                 Row(Modifier.weight(6f)) {
-                    Text(mod.name, style = MaterialTheme.typography.bodyLarge)
+                    val displayedName = if (mod.displayName.isEmpty()) mod.name else mod.displayName
+                    Text(displayedName, style = MaterialTheme.typography.bodyLarge)
                     // build list of mods that are incompatible with this mod
                     val incompatibleMods = state.versions.modGroups.flatMap { it.value }
                         .filter { it.incompatibleWith.contains(mod.name) || mod.incompatibleWith.contains(it.name) }
@@ -79,19 +80,28 @@ fun ModInfo(group: Group, mod: Mod) {
                             modifier = Modifier.alpha(0.5f),
                             tooltip = {
                                 Box(Modifier.background(MaterialTheme.colorScheme.background)) {
-                                    if (mod.requires.isNotEmpty()) {
+                                    if (mod.requires.isNotEmpty() && incompatibleMods.isNotEmpty()) {
                                         Text(
-                                            text = "Requires: ${mod.requires.joinToString()}",
+                                            text = "Incompatible with: ${incompatibleMods.joinToString()}\nRequires: ${mod.requires.joinToString()}",
                                             modifier = Modifier.padding(4.dp),
                                             style = MaterialTheme.typography.labelMedium
                                         )
                                     }
-                                    if (incompatibleMods.isNotEmpty()) {
-                                        Text(
-                                            text = "Incompatible with: ${incompatibleMods.joinToString()}",
-                                            modifier = Modifier.padding(4.dp),
-                                            style = MaterialTheme.typography.labelMedium
-                                        )
+                                    else {
+                                        if (mod.requires.isNotEmpty()) {
+                                            Text(
+                                                text = "Requires: ${mod.requires.joinToString()}",
+                                                modifier = Modifier.padding(4.dp),
+                                                style = MaterialTheme.typography.labelMedium
+                                            )
+                                        }
+                                        if (incompatibleMods.isNotEmpty()) {
+                                            Text(
+                                                text = "Incompatible with: ${incompatibleMods.joinToString()}",
+                                                modifier = Modifier.padding(4.dp),
+                                                style = MaterialTheme.typography.labelMedium
+                                            )
+                                        }
                                     }
                                 }
                             }

--- a/versions.yml
+++ b/versions.yml
@@ -210,6 +210,7 @@ modGroups:
       url: https://cdn.modrinth.com/data/rI0hvYcd/versions/uhvQD6Ny/visuality-0.7.1%2B1.20.jar
 
     - name: NotEnoughAnimations
+      displayName: Not Enough Animations
       license: MIT
       homepage: https://modrinth.com/mod/not-enough-animations
       modrinthId: MPCX6s5C
@@ -334,6 +335,7 @@ modGroups:
 
   Misc Enhancements:
     - name: First Person Models
+      displayName: First Person Model
       license: MIT
       homepage: https://modrinth.com/mod/first-person-model
       modrinthId: H5XMjpHi
@@ -408,6 +410,7 @@ modGroups:
       url: https://cdn.modrinth.com/data/FZcOyh3v/versions/XEAWEIcJ/nbttooltips-0.1.4-1.20.x.jar
 
     - name: Spark
+      displayName: spark
       license: GPL-3
       modrinthId: l6YH9Als
       homepage: https://modrinth.com/mod/spark
@@ -422,6 +425,7 @@ modGroups:
       url: https://cdn.modrinth.com/data/E9sX1ncV/versions/bTITl68h/IBEEditor-1.20.2-2.2.8-fabric.jar
 
     - name: RoughlyEnoughItems
+      displayName: Roughly Enough Items (REI)
       license: MIT
       homepage: https://modrinth.com/mod/rei
       desc: Alternative to Just Enough Items
@@ -434,11 +438,12 @@ modGroups:
       license: LGPL-3
       homepage: https://modrinth.com/mod/architectury-api
       modrinthId: lhGA9TYQ
-      desc: Dependency for RoughlyEnoughItems
+      desc: Cross-platform Dependency
       url: https://cdn.modrinth.com/data/lhGA9TYQ/versions/C2sB1Yq5/architectury-10.1.20-fabric.jar
       dependency: true
 
     - name: FabricKotlinLanguage
+      displayName: Fabric Language Kotlin
       license: APACHE
       homepage: https://modrinth.com/mod/fabric-language-kotlin
       modrinthId: Ha28R6CL


### PR DESCRIPTION
Adds optional `displayName` property to mods, this lets us change the name of the mod without causing issues. That means the original `name` works like an identifier for a mod and `displayName` can override that name in the rendering of the list without changing the file name and other stuff, it is purely visual.
Due to how Launchy works, it causes no issues on older versions at all, that property will simply be ignored completely

Additionally, fixes #53 
![image](https://github.com/Wynntils/launchy/assets/26695327/96e08d34-3098-4b6e-8c14-054294d0ddcb)
![image](https://github.com/Wynntils/launchy/assets/26695327/4925c2a6-5178-4e8a-aab2-e364cf344adc)
