### PR TITLE
chore: fix an incompatible mod pair

### DIFF
--- a/versions.yml
+++ b/versions.yml
@@ -231,6 +231,7 @@ modGroups:
       modrinthId: yBW8D80W
       desc: Holding a torch will light up your surroundings
       url: https://cdn.modrinth.com/data/yBW8D80W/versions/YgZzYuBw/lambdynamiclights-4.0.1%2B1.21.4.jar
+      incompatibleWith: [Sodium Dynamic Lights]
 
   Camera Enhancements:
     - name: Better Third Person

--- a/versions.yml
+++ b/versions.yml
@@ -217,6 +217,7 @@ modGroups:
       desc: Dynamic Lights for Sodium
       url: https://cdn.modrinth.com/data/PxQSWIcD/versions/aruAwiAC/sodiumdynamiclights-fabric-1.0.9-1.21.4.jar
       requires: [Forge Config API Port]
+      incompatibleWith: [Lamb Dynamic Lights]
 
     - name: Barriers Don't Block Rain
       license: CC0-1.0


### PR DESCRIPTION
Patches an incompatible mod pair:
 - Sodium Dynamic Lights is incompatible with Lamb Dynamic Lights